### PR TITLE
Add Cisco ISE IP to SGT miner

### DIFF
--- a/prototypes/ciscoise.yml
+++ b/prototypes/ciscoise.yml
@@ -22,7 +22,7 @@ prototypes:
       age_out:
         default: null
         sudden_death: true
-        interval: 233 # XXX set to 0 when possible
+        interval: null
 
   sgt_dag:
       author: MineMeld Core Team

--- a/prototypes/ciscoise.yml
+++ b/prototypes/ciscoise.yml
@@ -1,0 +1,37 @@
+url: http://www.cisco.com/c/en/us/products/security/identity-services-engine/index.html
+description: >
+  Cisco Identity Services Engine (ISE) allows you to see and control
+  users and devices connecting to the corporate network.
+
+prototypes:
+  ers_sgt:
+    author: MineMeld Core Team
+    development_status: EXPERIMENTAL
+    node_type: miner
+    description: >
+      IP to SGT (Security Group Tag) mappings from ISE using ERS (External
+      RESTful Services) API.
+    class: minemeld.ft.ciscoise.ErsSgt
+    config:
+      username: ers-operator
+      verify_cert: false
+      interval: 300
+      attributes:
+        confidence: 100
+        share_level: red
+      age_out:
+        default: null
+        sudden_death: true
+        interval: 233 # XXX set to 0 when possible
+
+  sgt_dag:
+      author: MineMeld Core Team
+      development_status: STABLE
+      node_type: output
+      description: >
+          Push IP to SGT mappings to PAN-OS devices via DAG.
+      class: minemeld.ft.dag.DagPusher
+      config:
+        persistent_registered_ips: false
+        tag_attributes:
+          - ise_sgt


### PR DESCRIPTION
Add experimental miner for IP to SGT (Security Group Tag) mappings
from Cisco Identity Services Engine (ISE) using ERS (External RESTful
Services) API.

Adds ciscoise.yml with 2 prototypes:

  ers_sgt: miner using class minemeld.ft.ciscoise.ErsSgt.  Config
  variables are:

    hostname: ISE hostname
    username: ERS API username (in ISE admin group ERS Operator)
    password: ERS API password
    verify_cert: HTTP Requests verify cert
    timeout: HTTP Requests timeout

    NOTE: These can be specified in the prototype config or a side config.

    prefix: SGT prefix (default ise_sgt)

  sgt_dag: output node using class minemeld.ft.dag.DagPusher to push
  IP to SGT mappings to PAN-OS devices via DAG (registered-ip).

minemeld.ft.dag.DagPusher has been modified to handle attributes of
type list for one to many IP to SGT cases.

Sample registered-ip objects:

  admin@PA-200> show object registered-ip all

  registered IP                             Tags
  ----------------------------------------  -----------------

  172.25.1.1
                                           "mmld_ise_sgt_Contractors"
                                           "mmld_pushed"

  10.0.0.1
                                           "mmld_ise_sgt_BYOD"
                                           "mmld_ise_sgt_Developers"
                                           "mmld_ise_sgt_Employees"
                                           "mmld_pushed"

  Total: 2 registered addresses
  *: received from user-id agent  #: persistent