### PR TITLE
Added indicator_types and tags attributes

### DIFF
--- a/prototypes/ETOpen.yml
+++ b/prototypes/ETOpen.yml
@@ -7,6 +7,12 @@ prototypes:
         author: Víctor Barahona (uam.es)
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceMedium
+            - ShareLevelGreen
+            - OSINT
         description: >
             This ruleset is compiled from a number of sources. It's contents
             are hosts that are known to be compromised by bots, phishing sites,
@@ -26,6 +32,12 @@ prototypes:
         author: Gregory Roehl (paloaltonetworks.com)
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceMedium
+            - ShareLevelGreen
+            - OSINT
         description: >
             Raw IPs for the firewall block lists. These come from
             Spam nets identified by Spamhaus (www.spamhaus.org), Top

--- a/prototypes/alienvault.yml
+++ b/prototypes/alienvault.yml
@@ -1,14 +1,16 @@
 description: >
-    AlienVault Reputation Monitor Alert is a free service that alerts you
-    whenever your public IPs and domains appear in the AlienVault Open Threat
-    Exchange (OTX).
-url: https://www.alienvault.com/open-threat-exchange/reputation-monitor
+    Open Source AlienVault Reputation Data.
+url: http://labs.alienvault.com/labs/index.php/projects/open-source-ip-reputation-portal/download-ip-reputation-database/
 
 prototypes:
     reputation:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ IPv4 ]
+        tags:
+            - OSINT
+            - ShareLevelGreen
         description: this just catches everything
         class: minemeld.ft.csv.CSVFT
         config:

--- a/prototypes/anomali.yml
+++ b/prototypes/anomali.yml
@@ -13,6 +13,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ domain, URL, IPv4, IPv6 ]
+        tags:
+            - ConfidenceHigh
+            - ConfidenceLow
+            - ConfidenceMedium
+            - ShareLevelRed
         description: >
             Miner for Anomali Optic API. You need a valid Optic API Key
             to use this Miner.

--- a/prototypes/auscert.yml
+++ b/prototypes/auscert.yml
@@ -8,6 +8,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 7 days combo
         config:
             source_name: auscert.7days_combo
@@ -22,6 +26,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 7 days malware
         config:
             source_name: auscert.7day_smalware
@@ -36,6 +44,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 7 days phishing
         config:
             source_name: auscert.7days_phishing
@@ -50,6 +62,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 7 days log or dump sites
         config:
             source_name: auscert.7days_dumpsites
@@ -64,6 +80,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 7 days muling
         config:
             source_name: auscert.7days_muling
@@ -78,6 +98,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 1 day combo
         config:
             source_name: auscert.1day_combo
@@ -92,6 +116,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:  [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 1 day malware
         config:
             source_name: auscert.1day_malware
@@ -106,6 +134,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 1 day phishing
         config:
             source_name: auscert.1day_phishing
@@ -120,6 +152,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ]
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 1 day1 log or dump sites
         config:
             source_name: auscert.1day_dumpsites
@@ -134,6 +170,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types: [ URL ] 
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: 1 day muling
         config:
             source_name: auscert.1day_muling

--- a/prototypes/autofocus.yml
+++ b/prototypes/autofocus.yml
@@ -11,6 +11,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+            - URL
+            - domain
+        tags:
+            - ConfidenceMedium
+            - ShareLevelRed
         description: >
             Miner for Autofocus Export List. You need a valid Autofocus API Key
             to use this Miner. Type of indicators: IPv4, URL, domain.

--- a/prototypes/aws.yml
+++ b/prototypes/aws.yml
@@ -9,6 +9,11 @@ prototypes:
         development_status: STABLE
         description: all AMAZON ranges
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.json.SimpleJSON
         config:
             source_name: aws.AMAZON
@@ -26,11 +31,17 @@ prototypes:
             attributes:
                 type: IPv4
                 confidence: 100
+                share_level: green
     EC2:
         author: MineMeld Core Team
         development_status: STABLE
         description: EC2 ranges
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.json.SimpleJSON
         config:
             source_name: aws.EC2
@@ -48,11 +59,17 @@ prototypes:
             attributes:
                 type: IPv4
                 confidence: 100
+                share_level: green
     ROUTE53:
         author: MineMeld Core Team
         development_status: STABLE
         description: ROUTE53 ranges
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.json.SimpleJSON
         config:
             source_name: aws.ROUTE53
@@ -70,11 +87,17 @@ prototypes:
             attributes:
                 type: IPv4
                 confidence: 100
+                share_level: green
     ROUTE53_HEALTHCHECKS:
         author: MineMeld Core Team
         development_status: STABLE
         description: ROUTE53_HEALTHCHECKS ranges
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.json.SimpleJSON
         config:
             source_name: aws.ROUTE53_HEALTHCHECKS
@@ -92,11 +115,17 @@ prototypes:
             attributes:
                 type: IPv4
                 confidence: 100
+                share_level: green
     CLOUDFRONT:
         author: MineMeld Core Team
         development_status: STABLE
         description: CLOUDFRONT ranges
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.json.SimpleJSON
         config:
             source_name: aws.CLOUDFRONT
@@ -114,3 +143,4 @@ prototypes:
             attributes:
                 type: IPv4
                 confidence: 100
+                share_level: green

--- a/prototypes/azure.yml
+++ b/prototypes/azure.yml
@@ -7,6 +7,11 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: >
             Public IP addresses of Microsoft Azure
         class: minemeld.ft.azure.AzureXML

--- a/prototypes/badips.yml
+++ b/prototypes/badips.yml
@@ -9,6 +9,12 @@ prototypes:
         author: CERT (uc3m.es)
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             blocklist with IPs of last 2 weeks any category and score > 3
         class: minemeld.ft.http.HttpFT

--- a/prototypes/bambenekconsulting.yml
+++ b/prototypes/bambenekconsulting.yml
@@ -7,8 +7,14 @@ url: http://osint.bambenekconsulting.com/feeds/
 prototypes:
     c2_ipmasterlist:
         author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             Master Feed of known, active and non-sinkholed C&Cs IP addresses
         class: minemeld.ft.csv.CSVFT
@@ -31,8 +37,14 @@ prototypes:
             source_name: bambenekconsulting.c2_ipmasterlist
     c2_dommasterlist:
         author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        development_status: STABLE
         node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             Master Feed of known, active and non-sinkholed C&Cs domain names
         class: minemeld.ft.csv.CSVFT
@@ -55,8 +67,14 @@ prototypes:
             source_name: bambenekconsulting.c2_dommasterlist
     c2_ipmasterlist_high:
         author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: >
             High Confidence Master Feed of known, active and non-sinkholed C&Cs IP addresses
         class: minemeld.ft.csv.CSVFT
@@ -79,8 +97,14 @@ prototypes:
             source_name: bambenekconsulting.c2_ipmasterlist_high
     c2_dommasterlist_high:
         author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        development_status: STABLE
         node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: >
             High Confidence Master Feed of known, active and non-sinkholed C&Cs domain names
         class: minemeld.ft.csv.CSVFT

--- a/prototypes/binarydefense.yml
+++ b/prototypes/binarydefense.yml
@@ -8,6 +8,12 @@ prototypes:
         author: Axel Bodart (ulg.ac.be)
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: The full banlist
         config:
             source_name: binarydefense.banlist

--- a/prototypes/blocklist_de.yml
+++ b/prototypes/blocklist_de.yml
@@ -9,6 +9,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses that have attacked one of our
             customers/servers in the last 48 hours.
@@ -25,6 +31,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the last
             48 hours as having run attacks on the service SSH
@@ -42,6 +54,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the last
             48 hours as having run attacks on the service Mail, Postfix.
@@ -59,6 +77,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the last
             48 hours as having run attacks on the service Apache,
@@ -76,6 +100,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the last
             48 hours for attacks on the Service imap, sasl, pop3..... 
@@ -93,6 +123,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the
             last 48 hours for attacks on the Service FTP. 
@@ -110,6 +146,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses that tried to login in a SIP-, VOIP- or 
             Asterisk-Server and are inclueded in the IPs-List from
@@ -128,6 +170,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IP addresses which have been reported within the
             last 48 hours as having run attacks attacks on the RFI-Attacks,
@@ -146,6 +194,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IPs which are older then 2 month and have more
             then 5.000 attacks. 
@@ -162,6 +216,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: ''
         config:
             source_name: blocklist_de.ircbot
@@ -176,6 +236,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         description: >
             All IPs which attacks Joomlas, Wordpress and other
             Web-Logins with Brute-Force Logins. 

--- a/prototypes/bruteforceblocker.yml
+++ b/prototypes/bruteforceblocker.yml
@@ -12,6 +12,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceMedium
+            - ShareLevelGreen
         class: minemeld.ft.http.HttpFT
         description: IP blocklist
         config:

--- a/prototypes/cif.yml
+++ b/prototypes/cif.yml
@@ -12,6 +12,16 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         description: >
             Miner for CIF API. Based on CIF SDK
             https://github.com/csirtgadgets/cif-sdk-py

--- a/prototypes/ciscoise.yml
+++ b/prototypes/ciscoise.yml
@@ -8,6 +8,12 @@ prototypes:
     author: MineMeld Core Team
     development_status: EXPERIMENTAL
     node_type: miner
+    indicator_types:
+      - IPv4
+      - IPv6
+    tags:
+      - ConfidenceHigh
+      - ShareLevelRed
     description: >
       IP to SGT (Security Group Tag) mappings from ISE using ERS (External
       RESTful Services) API.
@@ -28,6 +34,10 @@ prototypes:
       author: MineMeld Core Team
       development_status: STABLE
       node_type: output
+      indicator_types:
+        - IPv4
+        - IPv6
+      tags: []
       description: >
           Push IP to SGT mappings to PAN-OS devices via DAG.
       class: minemeld.ft.dag.DagPusher

--- a/prototypes/dshield.yml
+++ b/prototypes/dshield.yml
@@ -11,6 +11,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: suggested block list
         class: minemeld.ft.http.HttpFT
         config:

--- a/prototypes/feodotracker.yml
+++ b/prototypes/feodotracker.yml
@@ -20,6 +20,12 @@ prototypes:
           channels used by version A, version C and version D are not covered
           by this blocklist.
         node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
+            - OSINT
         config:
           source_name: feodotracker.domainblocklist
           attributes:
@@ -37,6 +43,12 @@ prototypes:
           Do not use, use feodotracker.domainblocklist instead. Will be removed in
           a future release.
         node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
+            - OSINT
         config:
           source_name: feodotracker.baddomains
           attributes:
@@ -63,6 +75,12 @@ prototypes:
           Feodo Trojan. C&C communication channels used by version A, version
           C and version D are not covered by this blocklist.
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
+            - OSINT
         config:
           source_name: feodotracker.badips
           attributes:
@@ -94,6 +112,12 @@ prototypes:
           and version D. If you only want to block/drop traffic to Feodo C&C
           servers hosted on bad IPs (version B), please use the blocklist BadIPs.
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceMedium
+            - ShareLevelGreen
+            - OSINT
         config:
           source_name: feodotracker.ipblocklist
           attributes:

--- a/prototypes/google.yml
+++ b/prototypes/google.yml
@@ -7,6 +7,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             Net blocks of Google services
         class: minemeld.ft.google.GoogleNetBlocks
@@ -21,6 +27,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             Net blocks of GCE
         class: minemeld.ft.google.GoogleCloudNetBlocks

--- a/prototypes/hailataxii.yml
+++ b/prototypes/hailataxii.yml
@@ -8,6 +8,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from Abuse_ch
         config:
@@ -18,6 +29,7 @@ prototypes:
             collection: guest.Abuse_ch
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -26,6 +38,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from CyberCrime_Tracker
         config:
@@ -36,6 +59,7 @@ prototypes:
             collection: guest.CyberCrime_Tracker
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -44,6 +68,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from EmergingThreats_rules
         config:
@@ -54,6 +89,7 @@ prototypes:
             collection: guest.EmergingThreats_rules
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -62,6 +98,17 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from Lehigh.edu
         config:
@@ -72,6 +119,7 @@ prototypes:
             collection: guest.Lehigh_edu
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -80,6 +128,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from MalwareDomainList_Hostlist
         config:
@@ -90,6 +149,7 @@ prototypes:
             collection: guest.MalwareDomainList_Hostlist
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -98,6 +158,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from blutmagie_de_torExits
         config:
@@ -108,6 +179,7 @@ prototypes:
             collection: guest.blutmagie_de_torExits
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -116,6 +188,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from dataForLast_7daysOnly
         config:
@@ -126,6 +209,7 @@ prototypes:
             collection: guest.dataForLast_7daysOnly
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -134,6 +218,17 @@ prototypes:
         author: Soltra Dev Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from dshield_BlockList
         config:
@@ -144,6 +239,7 @@ prototypes:
             collection: guest.dshield_BlockList
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d
@@ -152,6 +248,17 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
+            - ConfidenceMedium
+            - ConfidenceLow
         class: minemeld.ft.taxii.TaxiiClient
         description: public TAXII feed from phishtank.com
         config:
@@ -162,6 +269,7 @@ prototypes:
             collection: guest.phishtank_com
             attributes:
                 confidence: 30
+                share_level: green
             age_out:
                sudden_death: false
                default: 30d

--- a/prototypes/malwaredomainlist.yml
+++ b/prototypes/malwaredomainlist.yml
@@ -6,6 +6,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: list of active ip addresses
         config:
             source_name: malwaredomainlist.ip

--- a/prototypes/office365.yml
+++ b/prototypes/office365.yml
@@ -11,6 +11,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             The endpoints listed in this section are only to support the portal and identity
             portion of Office 365.
@@ -29,6 +36,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             If you have licensed Exchange Online as a standalone or as part of a suite, you
             must be able to reach the following endpoints.
@@ -47,6 +61,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             If you have licensed Skype for Business Online as a standalone or as part of a
             suite, you must be able to reach the Office 365 portal and identity URLs as well
@@ -66,6 +87,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             If you have licensed SharePoint Online as a standalone or as part of a suite,
             you must be able to reach the Office 365 portal and identity URLs as well as
@@ -85,6 +113,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             If you have licensed Exchange Online Protection (EOP) as a standalone or as part
             of a suite, you must be able to reach the Office 365 portal and identity URLs as
@@ -104,6 +139,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This list of IPv4 IP addresses is the current list required for the Office 365
             remote analyzer tools.
@@ -122,6 +164,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This list of URLs and IPv4 IP subnet is the current list required for Yammer.
         class: minemeld.ft.o365.O365XML
@@ -139,6 +188,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             Here is the current list of endpoints PCs and Macs need to be able to access
             to use Office 365 ProPlus.
@@ -157,6 +213,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This list of IP addresses is the current list required for Office Web Apps.
         class: minemeld.ft.o365.O365XML
@@ -174,6 +237,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Office for iPad URLs.
         class: minemeld.ft.o365.O365XML
@@ -191,6 +261,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Office Mobile URLs.
         class: minemeld.ft.o365.O365XML
@@ -208,6 +285,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Planner IPs and URLs.
         class: minemeld.ft.o365.O365XML
@@ -225,6 +309,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of OneNote IPs and URLs.
         class: minemeld.ft.o365.O365XML
@@ -242,6 +333,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Office 365 authentication and
             identity IPs and URLs.
@@ -260,6 +358,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Sway IPs and URLs.
         class: minemeld.ft.o365.O365XML
@@ -277,6 +382,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Office365 Video IPs and URLs.
         class: minemeld.ft.o365.O365XML
@@ -294,6 +406,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - URL
+            - IPv6
+            - IPv4
+        tags:
+            - ShareLevelGreen
+            - ConfidenceHigh
         description: >
             This is the current list of Office365 CRLs IPs and URLs.
         class: minemeld.ft.o365.O365XML

--- a/prototypes/openbl.yml
+++ b/prototypes/openbl.yml
@@ -13,6 +13,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: The suggested DEFAULT list
         config:
             source_name: openbl.base
@@ -28,6 +34,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 1 days
         config:
             source_name: openbl.base_1days
@@ -43,6 +55,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 7 days
         config:
             source_name: openbl.base_7days
@@ -58,6 +76,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 30 days
         config:
             source_name: openbl.base_30days
@@ -73,6 +97,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 60 days
         config:
             source_name: openbl.base_60days
@@ -88,6 +118,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: openbl.base_90days
         config:
             source_name: https://www.openbl.org/lists/base_90days.txt
@@ -103,6 +139,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 180 days
         config:
             source_name: openbl.base_180days
@@ -118,6 +160,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: IP list for last 360 days
         config:
             source_name: openbl.base_360days

--- a/prototypes/openphish.yml
+++ b/prototypes/openphish.yml
@@ -8,6 +8,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - URL
+        tags:
+            - OSINT
+            - ShareLevelGreen
+            - ConfidenceMedium
         description: The free feed
         config:
             source_name: openphish.feed

--- a/prototypes/phishme.yml
+++ b/prototypes/phishme.yml
@@ -12,6 +12,15 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - domain
+            - URL
+        tags:
+            - ShareLevelRed
+            - ConfidenceLow
+            - ConfidenceMedium
+            - ConfidenceHigh
         description: >
             PhishMe Intelligence provides accurate and timely alerts so that
             you can be ready to take fast action when under attack. PhishMe

--- a/prototypes/proofpoint.yml
+++ b/prototypes/proofpoint.yml
@@ -10,6 +10,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+        tags:
+            - ConfidenceMedium
+            - ShareLevelRed
         description: >
             Detailed feed of IPs classified in different categories.
             You need a valid authorization code from Proofpoint ET
@@ -29,6 +35,11 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: >
             Detailed feed of domains classified in different categories.
             You need a valid authorization code from Proofpoint ET

--- a/prototypes/ransomwaretracker.yml
+++ b/prototypes/ransomwaretracker.yml
@@ -9,6 +9,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: CryptoWall C2 URLs
         config:
           source_name: ransomwaretracker.CW_C2_URLBL
@@ -27,6 +33,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceLow
+          - ShareLevelGreen
         description: CryptoWall C2 domains
         config:
           source_name: ransomwaretracker.CW_C2_DOMBL
@@ -45,6 +57,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: CryptoWall C2 Payment Sites domains
         config:
           source_name: ransomwaretracker.CW_PS_DOMBL
@@ -63,6 +81,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: CryptoWall Payment Sites IPs
         config:
           source_name: ransomwaretracker.CW_PS_IPBL
@@ -82,6 +107,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: TeslaCrypt C2 URLs
         config:
           source_name: ransomwaretracker.TC_C2_URLBL
@@ -100,6 +131,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceLow
+          - ShareLevelGreen
         description: TeslaCrypt C2 domains
         config:
           source_name: ransomwaretracker.TC_C2_DOMBL
@@ -118,6 +155,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceLow
+          - ShareLevelGreen
         description: TeslaCrypt Payment Sites domains
         config:
           source_name: ransomwaretracker.TC_PS_DOMBL
@@ -136,6 +179,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: TeslaCrypt Payment Sites IPs
         config:
           source_name: ransomwaretracker.TC_PS_IPBL
@@ -155,6 +205,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: TeslaCrypt Distribution Sites URLs
         config:
           source_name: ransomwaretracker.TC_DS_URLBL
@@ -173,6 +229,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: Locky C2 domains
         config:
           source_name: ransomwaretracker.LY_C2_DOMBL
@@ -191,6 +253,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: Locky IPs
         config:
           source_name: ransomwaretracker.LY_C2_IPBL
@@ -210,6 +279,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: Locky Payment Sites domains
         config:
           source_name: ransomwaretracker.LY_PS_DOMBL
@@ -228,6 +303,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceLow
+          - ShareLevelGreen
         description: Locky Payment Sites IPs
         config:
           source_name: ransomwaretracker.LY_PS_IPBL
@@ -246,6 +327,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: Locky Distribution Sites URLs
         config:
           source_name: ransomwaretracker.LY_DS_URLBL
@@ -264,6 +351,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: TorrentLocker C2 domains
         config:
           source_name: ransomwaretracker.TL_C2_DOMBL
@@ -282,6 +375,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: TorrentLocker C2 IPs
         config:
           source_name: ransomwaretracker.TL_C2_IPBL
@@ -301,6 +401,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: TorrentLocker Payment Sites domains
         config:
           source_name: ransomwaretracker.TL_PS_DOMBL
@@ -319,6 +425,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: TorrentLocker Payment Sites IPs
         config:
           source_name: ransomwaretracker.TL_PS_IPBL
@@ -338,6 +451,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: Combined Ransomware domains
         config:
           source_name: ransomwaretracker.RW_DOMBL
@@ -356,6 +475,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: Combined Ransomware URLs
         config:
           source_name: ransomwaretracker.RW_URLBL
@@ -374,6 +499,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceMedium
+          - ShareLevelGreen
+          - DirectionOutbound
         description: Combined Ransomware IPs
         config:
           source_name: ransomwaretracker.RW_IPBL

--- a/prototypes/recordedfuture.yml
+++ b/prototypes/recordedfuture.yml
@@ -11,6 +11,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: >
             Recorded Future continually analyzes indicator-related reporting
             from sources including websites, blogs, paste sites, IRC, malware

--- a/prototypes/spamhaus.yml
+++ b/prototypes/spamhaus.yml
@@ -12,6 +12,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: Spamhaus Don't Route Or Peer List (DROP)
         config:
             source_name: spamhaus.DROP
@@ -34,6 +40,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: Spamhaus Extended DROP List (EDROP)
         config:
             source_name: spamhaus.EDROP

--- a/prototypes/sslabusech.yml
+++ b/prototypes/sslabusech.yml
@@ -12,6 +12,12 @@ prototypes:
             seen in the past 30 days being associated with a malicious SSL
             certificate.
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         class: minemeld.ft.csv.CSVFT
         config:
             url: https://sslbl.abuse.ch/blacklist/sslipblacklist.csv
@@ -29,6 +35,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - OSINT
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: Dyre SSL blacklist
         class: minemeld.ft.csv.CSVFT
         config:

--- a/prototypes/stdlib.yml
+++ b/prototypes/stdlib.yml
@@ -6,6 +6,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - URL
+        tags: []
         description: >
             Aggregator for URL indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -33,6 +36,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: processor
+        indicator_types:
+          - IPv6
+        tags: []
         description: >
             Simple aggregator for IPv6 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -60,6 +66,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - domain
+        tags: []
         description: >
             Aggregator for domain indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -87,6 +96,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - IPv4
+        tags: []
         description: >
             Generic Aggregator for IPv4 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -114,6 +126,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - IPv4
+        tags: []
         description: >
             Aggregator for inbound IPv4 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -148,6 +163,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - IPv4
+        tags: []
         description: >
             Aggregator for outbound IPv4 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -182,6 +200,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - md5
+        tags: []
         description: >
             Aggregator for MD5 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -209,6 +230,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - sha1
+        tags: []
         description: >
             Aggregator for SHA1 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -236,6 +260,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - sha256
+        tags: []
         description: >
             Aggregator for SHA256 indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -263,6 +290,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - ssdeep
+        tags: []
         description: >
             Aggregator for ssdeep indicators.
             Inputs with names starting with "wl" will be interpreted as
@@ -290,6 +320,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ShareLevelGreen
+          - ConfidenceLow
         description: >
             EDL for low confidence indicators (<50) and share level green
         class: minemeld.ft.redis.RedisSet
@@ -314,6 +348,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceMedium
+          - ShareLevelGreen
         description: >
             EDL for medium confidence indicators (>=50,<75) and share level green
         class: minemeld.ft.redis.RedisSet
@@ -339,6 +377,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: >
             EDL for high confidence indicators (>75) and share level green
         class: minemeld.ft.redis.RedisSet
@@ -363,6 +405,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceLow
+          - ShareLevelGreen
         description: >
             EDL for low confidence indicators (<50) and share level green, with value
         class: minemeld.ft.redis.RedisSet
@@ -388,6 +434,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceMedium
+          - ShareLevelGreen
         description: >
             EDL for medium confidence indicators (>=50,<75) and share level green, with value
         class: minemeld.ft.redis.RedisSet
@@ -414,6 +464,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceHigh
+          - ShareLevelGreen
         description: >
             EDL for high confidence indicators (>75) and share level green, with value
         class: minemeld.ft.redis.RedisSet
@@ -439,6 +493,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceLow
         description: >
             EDL for low confidence indicators (<50), with value
         class: minemeld.ft.redis.RedisSet
@@ -463,6 +520,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceMedium
         description: >
             EDL for medium confidence indicators (>=50,<75), with value
         class: minemeld.ft.redis.RedisSet
@@ -488,6 +548,9 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceHigh
         description: >
             EDL for high confidence indicators (>75), with value
         class: minemeld.ft.redis.RedisSet
@@ -512,6 +575,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+          - URL
+          - IPv4
+          - IPv6
+        tags:
+          - ConfidenceMedium
         description: >
             Miner for PAN-OS syslog messages
         class: minemeld.ft.syslog.SyslogMiner
@@ -524,6 +593,11 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: processor
+        indicator_types:
+          - domain
+          - IPv4
+          - IPv6
+        tags: []
         description: >
             Syslog node connection to the local syslog server to receive PAN-OS logs
         class: minemeld.ft.syslog.SyslogMatcher
@@ -533,6 +607,11 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: processor
+        indicator_types:
+          - IPv4
+          - IPv6
+          - domain
+        tags: []
         description: >
             Syslog node connection to the local syslog server to receive PAN-OS logs.
             This prototype also logs matching sessions/indicators pairs to a Logstash
@@ -546,6 +625,8 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags: []
         description: >
             Logstash node to send indicators message to a local logstash instance on
             port 5514
@@ -558,6 +639,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types:
+          - IPv4
+          - IPv6
+        tags: []
         description: >
             Push IP unicast indicators to PAN-OS devices via DAG.
         class: minemeld.ft.dag.DagPusher
@@ -567,6 +652,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types:
+          - IPv4
+          - IPv6
+        tags: []
         description: >
             Push IP unicast indicators to PAN-OS devices via DAG. Generates
             non persistent registered IPs.
@@ -578,6 +667,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceLow
+          - ShareLevelRed
         description: >
             EDL for low confidence indicators (<50) and share level red, with value
         class: minemeld.ft.redis.RedisSet
@@ -603,6 +696,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceMedium
+          - ShareLevelRed
         description: >
             EDL for medium confidence indicators (>=50,<75) and share level red, with value
         class: minemeld.ft.redis.RedisSet
@@ -629,6 +726,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: output
+        indicator_types: [ any ]
+        tags:
+          - ConfidenceHigh
+          - ShareLevelRed
         description: >
             EDL for high confidence indicators (>75) and share level red, with value
         class: minemeld.ft.redis.RedisSet
@@ -654,6 +755,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - ConfidenceHigh
         description: >
             list of IPv4 addresses. Use a name starting with "wl" to create a whitelist for
             an aggregator
@@ -672,6 +777,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+          - IPv6
+        tags:
+          - ConfidenceHigh
         description: >
             list of IPv6 addresses. Use a name starting with "wl" to create a whitelist for
             an aggregator
@@ -690,6 +799,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+          - URL
+        tags:
+          - ConfidenceHigh
         description: >
             list of URLs. Use a name starting with "wl" to create a whitelist for
             an aggregator
@@ -708,6 +821,10 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - ConfidenceHigh
         description: >
             list of domain. Use a name starting with "wl" to create a whitelist for
             an aggregator
@@ -726,7 +843,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: output
+        indicator_types:
+          - IPv4
+          - IPv6
+          - domain
+          - URL
+        tags: []
         description: TAXII DataFeed
         class: minemeld.ft.taxii.DataFeed
         config: {}
-

--- a/prototypes/themediatrust.yml
+++ b/prototypes/themediatrust.yml
@@ -13,6 +13,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - domain
+            - IPv4
+        tags:
+            - ShareLevelRed
+            - ConfidenceMedium
         description: >
             Miner for The Media Trust DTI API. You need a valid TMT DTI API
             Key to use this Miner.

--- a/prototypes/threatq.yml
+++ b/prototypes/threatq.yml
@@ -10,6 +10,14 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - ShareLevelAmber
+            - ConfidenceHigh
         description: >
             Miner for Threatq Export API. This prototype sets confidence
             of produced indicators to 100 (High Confidence).
@@ -28,6 +36,14 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - ShareLevelAmber
+            - ConfidenceMedium
         description: >
             Miner for Threatq Export API. This prototype sets confidence
             of produced indicators to 70 (Medium Confidence).
@@ -46,6 +62,14 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+            - IPv6
+            - domain
+            - URL
+        tags:
+            - ShareLevelAmber
+            - ConfidenceLow
         description: >
             Miner for Threatq Export API. This prototype sets confidence
             of produced indicators to 30 (Low Confidence).

--- a/prototypes/tor.yml
+++ b/prototypes/tor.yml
@@ -10,6 +10,11 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelGreen
         description: Tor Exit addresses
         class: minemeld.ft.http.HttpFT
         config:

--- a/prototypes/virbl.yml
+++ b/prototypes/virbl.yml
@@ -9,6 +9,12 @@ prototypes:
         author: MineMeld Core Team
         development_status: STABLE
         node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - OSINT
+            - ShareLevelGreen
         class: minemeld.ft.http.HttpFT
         description: virbl IP blocklist
         config:

--- a/prototypes/virustotal.yml
+++ b/prototypes/virustotal.yml
@@ -9,6 +9,13 @@ prototypes:
         author: MineMeld Core Team
         development_status: EXPERIMENTAL
         node_type: miner
+        indicator_types:
+            - md5
+            - sha256
+            - sha1
+        tags:
+            - ConfidenceHigh
+            - ShareLevelRed
         description: >
             Miner for VirusTotal Intelligence Notifications feed.
         config:

--- a/prototypes/zeustracker.yml
+++ b/prototypes/zeustracker.yml
@@ -15,6 +15,12 @@ prototypes:
           (level 2). Hence the false positive rate should be much lower compared
           to the standard ZeuS domain blocklist.
         node_type: miner
+        indicator_types:
+          - domain
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
         config:
           source_name: zeustracker.baddomains
           attributes:
@@ -36,6 +42,13 @@ prototypes:
           false postive rate should be much lower compared to the standard ZeuS IP
           blocklist (see below).
         node_type: miner
+        indicator_types:
+          - IPv4
+        tags:
+          - OSINT
+          - ConfidenceHigh
+          - ShareLevelGreen
+          - DirectionOutbound
         config:
           source_name: zeustracker.badips
           attributes:

--- a/tests/test_prototypes.py
+++ b/tests/test_prototypes.py
@@ -25,6 +25,11 @@ def _check_library(l):
         assert 'class' in prototype, "No class field in %s::%s" % (l, p)
         assert 'config' in prototype, "No config field in %s::%s" % (l, p)
         assert 'node_type' in prototype, "No node_type field in %s::%s" % (l, p)
+        assert 'tags' in prototype, "No tags field in %s::%s" % (l, p)
+        assert isinstance(prototype['tags'], list), "Wrong type for attribute tags in %s::%s" % (l, p)
+        assert 'indicator_types' in prototype, "No indicator_types field in %s::%s" % (l, p)
+        assert isinstance(prototype['indicator_types'], list), "Wrong type for attribute indicator_types in %s::%s" % (l, p)
+        assert len(prototype['indicator_types']), "0 indicator_types in %s::%s" % (l, p)
 
 def test_prototypes():
     libraries = [os.path.join('prototypes', x) for x in os.listdir('prototypes')]


### PR DESCRIPTION
## Motivation

In the current release to understand which kind of indicators are processed or generated by a node a good understanding of the node implementation and configuration is needed. This patch adds some new metadata to prototypes to be used to describe new context around each prototype.

## Modifications

Added 2 new fields to prototypes:
- *indicator_types* is a list of type of indicators supported or generated by this prototype. *any* can be used to tell that any type of indicator is supported (example: for feed output nodes)
- *tags* is a list of tags where additional context can be captured. Like *ConfidenceHigh*, *ShareLevelGreen*, ... 

## Result

Improve usability of the prototype library

Signed-off-by: Luigi Mori <lmori@paloaltonetworks.com>