### PR TITLE
Changed to use the XML Feeds, as the URLs in that feed are more complete

### DIFF
--- a/prototypes/auscert.yml
+++ b/prototypes/auscert.yml
@@ -15,7 +15,10 @@ prototypes:
         description: 7 days combo
         config:
             source_name: auscert.7days_combo
-            url: https://www.auscert.org.au/download.html?f=628
+            url: https://www.auscert.org.au/download.html?f=279
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -33,7 +36,10 @@ prototypes:
         description: 7 days malware
         config:
             source_name: auscert.7day_smalware
-            url: https://www.auscert.org.au/download.html?f=790
+            url: https://www.auscert.org.au/download.html?f=273
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -51,7 +57,10 @@ prototypes:
         description: 7 days phishing
         config:
             source_name: auscert.7days_phishing
-            url: https://www.auscert.org.au/download.html?f=791
+            url: https://www.auscert.org.au/download.html?f=271
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -69,7 +78,10 @@ prototypes:
         description: 7 days log or dump sites
         config:
             source_name: auscert.7days_dumpsites
-            url: https://www.auscert.org.au/download.html?f=792
+            url: https://www.auscert.org.au/download.html?f=277
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -87,7 +99,10 @@ prototypes:
         description: 7 days muling
         config:
             source_name: auscert.7days_muling
-            url: https://www.auscert.org.au/download.html?f=793
+            url: https://www.auscert.org.au/download.html?f=275
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -105,7 +120,10 @@ prototypes:
         description: 1 day combo
         config:
             source_name: auscert.1day_combo
-            url: https://www.auscert.org.au/download.html?f=627
+            url: https://www.auscert.org.au/download.html?f=280
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -123,7 +141,10 @@ prototypes:
         description: 1 day malware
         config:
             source_name: auscert.1day_malware
-            url: https://www.auscert.org.au/download.html?f=794
+            url: https://www.auscert.org.au/download.html?f=274
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -141,7 +162,10 @@ prototypes:
         description: 1 day phishing
         config:
             source_name: auscert.1day_phishing
-            url: https://www.auscert.org.au/download.html?f=795
+            url: https://www.auscert.org.au/download.html?f=272
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -159,7 +183,10 @@ prototypes:
         description: 1 day1 log or dump sites
         config:
             source_name: auscert.1day_dumpsites
-            url: https://www.auscert.org.au/download.html?f=796
+            url: https://www.auscert.org.au/download.html?f=278
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -177,7 +204,10 @@ prototypes:
         description: 1 day muling
         config:
             source_name: auscert.1day_muling
-            url: https://www.auscert.org.au/download.html?f=797
+            url: https://www.auscert.org.au/download.html?f=276
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red


### PR DESCRIPTION
The one line per file data feeds sometimes truncate the URLs, the XML feeds is a more reliable source.