### PR TITLE
Update the AusCERT prototype to use the XML feeds.

### DIFF
--- a/prototypes/auscert.yml
+++ b/prototypes/auscert.yml
@@ -5,8 +5,8 @@ description: >
 
 prototypes:
     7days_combo:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -15,7 +15,10 @@ prototypes:
         description: 7 days combo
         config:
             source_name: auscert.7days_combo
-            url: https://www.auscert.org.au/download.html?f=628
+            url: https://www.auscert.org.au/download.html?f=279
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -23,8 +26,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     7days_malware:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -33,7 +36,10 @@ prototypes:
         description: 7 days malware
         config:
             source_name: auscert.7day_smalware
-            url: https://www.auscert.org.au/download.html?f=790
+            url: https://www.auscert.org.au/download.html?f=273
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -41,8 +47,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     7days_phishing:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -51,7 +57,10 @@ prototypes:
         description: 7 days phishing
         config:
             source_name: auscert.7days_phishing
-            url: https://www.auscert.org.au/download.html?f=791
+            url: https://www.auscert.org.au/download.html?f=271
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -59,8 +68,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     7days_dumpsites:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -69,7 +78,10 @@ prototypes:
         description: 7 days log or dump sites
         config:
             source_name: auscert.7days_dumpsites
-            url: https://www.auscert.org.au/download.html?f=792
+            url: https://www.auscert.org.au/download.html?f=277
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -77,8 +89,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     7days_muling:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -87,7 +99,10 @@ prototypes:
         description: 7 days muling
         config:
             source_name: auscert.7days_muling
-            url: https://www.auscert.org.au/download.html?f=793
+            url: https://www.auscert.org.au/download.html?f=275
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -95,8 +110,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     1day_combo:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -105,7 +120,10 @@ prototypes:
         description: 1 day combo
         config:
             source_name: auscert.1day_combo
-            url: https://www.auscert.org.au/download.html?f=627
+            url: https://www.auscert.org.au/download.html?f=280
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -113,8 +131,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     1day_malware:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types:  [ URL ]
         tags:
@@ -123,7 +141,10 @@ prototypes:
         description: 1 day malware
         config:
             source_name: auscert.1day_malware
-            url: https://www.auscert.org.au/download.html?f=794
+            url: https://www.auscert.org.au/download.html?f=274
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -131,8 +152,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     1day_phishing:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -141,7 +162,10 @@ prototypes:
         description: 1 day phishing
         config:
             source_name: auscert.1day_phishing
-            url: https://www.auscert.org.au/download.html?f=795
+            url: https://www.auscert.org.au/download.html?f=272
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -149,8 +173,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     1day_dumpsites:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ]
         tags:
@@ -159,7 +183,10 @@ prototypes:
         description: 1 day1 log or dump sites
         config:
             source_name: auscert.1day_dumpsites
-            url: https://www.auscert.org.au/download.html?f=796
+            url: https://www.auscert.org.au/download.html?f=278
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red
@@ -167,8 +194,8 @@ prototypes:
         class: minemeld.ft.auscert.MaliciousURLFeed
 
     1day_muling:
-        author: MineMeld Core Team
-        development_status: EXPERIMENTAL
+        author: Simon Coggins
+        development_status: STABLE
         node_type: miner
         indicator_types: [ URL ] 
         tags:
@@ -177,7 +204,10 @@ prototypes:
         description: 1 day muling
         config:
             source_name: auscert.1day_muling
-            url: https://www.auscert.org.au/download.html?f=797
+            url: https://www.auscert.org.au/download.html?f=276
+            indicator:
+                regex: '<uri>(.*)</uri>'
+                transform: '\1'
             attributes:
                 type: URL
                 share_level: red


### PR DESCRIPTION
This change is to update the URLs and indicator extraction to use the AusCERT XML feeds which are more reliable for parsing. 

The status and author have also been changed to Stable, and myself as requested by Luigi on the last pull request.

-Simon