### PR TITLE
Updated to AusCERTs new malware API

### DIFF
--- a/prototypes/auscert.yml
+++ b/prototypes/auscert.yml
@@ -15,7 +15,7 @@ prototypes:
         description: 7 days combo
         config:
             source_name: auscert.7days_combo
-            url: https://www.auscert.org.au/download.html?f=279
+            url: https://www.auscert.org.au/api/v1/malurl/combo-7-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -36,7 +36,7 @@ prototypes:
         description: 7 days malware
         config:
             source_name: auscert.7day_smalware
-            url: https://www.auscert.org.au/download.html?f=273
+            url: https://www.auscert.org.au/api/v1/malurl/malware-7-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -57,49 +57,7 @@ prototypes:
         description: 7 days phishing
         config:
             source_name: auscert.7days_phishing
-            url: https://www.auscert.org.au/download.html?f=271
-            indicator:
-                regex: '<uri>(.*)</uri>'
-                transform: '\1'
-            attributes:
-                type: URL
-                share_level: red
-                confidence: 80
-        class: minemeld.ft.auscert.MaliciousURLFeed
-
-    7days_dumpsites:
-        author: Simon Coggins
-        development_status: STABLE
-        node_type: miner
-        indicator_types: [ URL ]
-        tags:
-            - ConfidenceHigh
-            - ShareLevelRed
-        description: 7 days log or dump sites
-        config:
-            source_name: auscert.7days_dumpsites
-            url: https://www.auscert.org.au/download.html?f=277
-            indicator:
-                regex: '<uri>(.*)</uri>'
-                transform: '\1'
-            attributes:
-                type: URL
-                share_level: red
-                confidence: 80
-        class: minemeld.ft.auscert.MaliciousURLFeed
-
-    7days_muling:
-        author: Simon Coggins
-        development_status: STABLE
-        node_type: miner
-        indicator_types: [ URL ]
-        tags:
-            - ConfidenceHigh
-            - ShareLevelRed
-        description: 7 days muling
-        config:
-            source_name: auscert.7days_muling
-            url: https://www.auscert.org.au/download.html?f=275
+            url: https://www.auscert.org.au/api/v1/malurl/phishing-7-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -120,7 +78,7 @@ prototypes:
         description: 1 day combo
         config:
             source_name: auscert.1day_combo
-            url: https://www.auscert.org.au/download.html?f=280
+            url: https://www.auscert.org.au/api/v1/malurl/combo-1-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -141,7 +99,7 @@ prototypes:
         description: 1 day malware
         config:
             source_name: auscert.1day_malware
-            url: https://www.auscert.org.au/download.html?f=274
+            url: https://www.auscert.org.au/api/v1/malurl/malware-1-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -162,7 +120,7 @@ prototypes:
         description: 1 day phishing
         config:
             source_name: auscert.1day_phishing
-            url: https://www.auscert.org.au/download.html?f=272
+            url: https://www.auscert.org.au/api/v1/malurl/malware-1-xml
             indicator:
                 regex: '<uri>(.*)</uri>'
                 transform: '\1'
@@ -172,44 +130,3 @@ prototypes:
                 confidence: 80
         class: minemeld.ft.auscert.MaliciousURLFeed
 
-    1day_dumpsites:
-        author: Simon Coggins
-        development_status: STABLE
-        node_type: miner
-        indicator_types: [ URL ]
-        tags:
-            - ConfidenceHigh
-            - ShareLevelRed
-        description: 1 day1 log or dump sites
-        config:
-            source_name: auscert.1day_dumpsites
-            url: https://www.auscert.org.au/download.html?f=278
-            indicator:
-                regex: '<uri>(.*)</uri>'
-                transform: '\1'
-            attributes:
-                type: URL
-                share_level: red
-                confidence: 80
-        class: minemeld.ft.auscert.MaliciousURLFeed
-
-    1day_muling:
-        author: Simon Coggins
-        development_status: STABLE
-        node_type: miner
-        indicator_types: [ URL ] 
-        tags:
-            - ConfidenceHigh
-            - ShareLevelRed
-        description: 1 day muling
-        config:
-            source_name: auscert.1day_muling
-            url: https://www.auscert.org.au/download.html?f=276
-            indicator:
-                regex: '<uri>(.*)</uri>'
-                transform: '\1'
-            attributes:
-                type: URL
-                share_level: red
-                confidence: 80
-        class: minemeld.ft.auscert.MaliciousURLFeed


### PR DESCRIPTION
AusCERT has changed over to using a new API for the malware feed. This changes the URLs for the feeds. It also removes some of the old ones. So only combined, phishing and malware exist now for 1 day or 7 days. The prototype has been updated accordingly.

Signed-off-by: Simon Coggins <s.coggins@cqu.edu.au>