### PR TITLE
libraesva prototype

### DIFF
--- a/prototypes/libraesva.yml
+++ b/prototypes/libraesva.yml
@@ -1,0 +1,201 @@
+url: https://libraesva.com/
+description: >
+    Libraesva Reputation Services provides high quality data feeds about email threats, spam and malware.
+    Most of the threats that these feeds allow to block are unknown to any other public source.
+    The feeds are updated very frequently and they are kept clean. Ceased threats are automatically removed.
+    We aim at a false positive rate close to zero while maintaining a high efficiency in blocking threats
+    that are yet unknown to any public source.
+    The feeds are free to use but we require a free registration. Go to https://docs.libraesva.com/esvalabs-ioc-access-request/ to request access.
+prototypes:
+
+    LIBRAESVA_Advertising_Domains:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: Domains delivering advertising only
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: domain
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.advertising_domains
+		url: https://repo.libraesva.com/ioc/domain.black.txt
+        class: minemeld.ft.http.HttpFT
+
+    LIBRAESVA_Bulk_Email_Domains:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: Domains delivering bulk email traffic
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: domain
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.bulk_email
+		url: https://repo.libraesva.com/ioc/domain.grey.txt
+        class: minemeld.ft.http.HttpFT
+
+
+    LIBRAESVA_White_Domains:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: Legit email and web domains
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: domain
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.white_domains
+		url: https://repo.libraesva.com/ioc/domain.white.txt
+        class: minemeld.ft.http.HttpFT
+
+    LIBRAESVA_Malware_Domains:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - domain
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: Malware,phishing,comprimised sites..
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: domain
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.malware_domains
+		url: http://repo.libraesva.com/ioc/domain.malware.txt
+        class: minemeld.ft.http.HttpFT
+
+    LIBRAESVA_Advertising_IP4:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: IPv4 classes delivering advertising email traffic only
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: IPv4
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.advertising_ip4
+		url: https://repo.libraesva.com/ioc/ip.black.txt
+        class: minemeld.ft.http.HttpFT
+
+
+    LIBRAESVA_Bulk_IP4:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - IPv4
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: IPv4 classess delivering bulk email traffic
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: IPv4
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.bulk_ip4
+		url: https://repo.libraesva.com/ioc/ip.grey.txt
+        class: minemeld.ft.http.HttpFT
+
+    LIBRAESVA_Bad_Email_IXHASH:
+        author: LibraEsva Team
+        development_status: STABLE
+        node_type: miner
+        indicator_types:
+            - md5
+        tags:
+            - ConfidenceHigh
+            - ShareLevelYellow
+        description: Undesired email hashes, uses IX hash algoritm
+        config:
+		age_out:
+		    default: null
+		    interval: 600
+		    sudden_death: true
+		attributes:
+		    confidence: 100
+		    direction: inbound
+		    share_level: yellow
+		    type: IPv4
+		ignore_regex: ^#.*
+		indicator:
+		    regex: ^.*
+		source_name: libraesva.bad_email_ixhash
+		url: https://repo.libraesva.com/ioc/ix.black.txt
+        class: minemeld.ft.http.HttpFT
+

--- a/prototypes/libraesva.yml
+++ b/prototypes/libraesva.yml
@@ -191,7 +191,7 @@ prototypes:
 		    confidence: 100
 		    direction: inbound
 		    share_level: yellow
-		    type: IPv4
+		    type: md5
 		ignore_regex: ^#.*
 		indicator:
 		    regex: ^.*

--- a/prototypes/libraesva.yml
+++ b/prototypes/libraesva.yml
@@ -6,8 +6,8 @@ description: >
     We aim at a false positive rate close to zero while maintaining a high efficiency in blocking threats
     that are yet unknown to any public source.
     The feeds are free to use but we require a free registration. Go to https://docs.libraesva.com/esvalabs-ioc-access-request/ to request access.
-prototypes:
 
+prototypes:
     LIBRAESVA_Advertising_Domains:
         author: LibraEsva Team
         development_status: STABLE
@@ -19,20 +19,20 @@ prototypes:
             - ShareLevelYellow
         description: Domains delivering advertising only
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: domain
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.advertising_domains
-		url: https://repo.libraesva.com/ioc/domain.black.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: domain
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.advertising_domains
+        url: https://repo.libraesva.com/ioc/domain.black.txt
         class: minemeld.ft.http.HttpFT
 
     LIBRAESVA_Bulk_Email_Domains:
@@ -46,22 +46,21 @@ prototypes:
             - ShareLevelYellow
         description: Domains delivering bulk email traffic
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: domain
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.bulk_email
-		url: https://repo.libraesva.com/ioc/domain.grey.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: domain
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.bulk_email
+        url: https://repo.libraesva.com/ioc/domain.grey.txt
         class: minemeld.ft.http.HttpFT
-
 
     LIBRAESVA_White_Domains:
         author: LibraEsva Team
@@ -74,20 +73,20 @@ prototypes:
             - ShareLevelYellow
         description: Legit email and web domains
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: domain
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.white_domains
-		url: https://repo.libraesva.com/ioc/domain.white.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: domain
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.white_domains
+        url: https://repo.libraesva.com/ioc/domain.white.txt
         class: minemeld.ft.http.HttpFT
 
     LIBRAESVA_Malware_Domains:
@@ -101,20 +100,20 @@ prototypes:
             - ShareLevelYellow
         description: Malware,phishing,comprimised sites..
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: domain
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.malware_domains
-		url: http://repo.libraesva.com/ioc/domain.malware.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: domain
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.malware_domains
+        url: http://repo.libraesva.com/ioc/domain.malware.txt
         class: minemeld.ft.http.HttpFT
 
     LIBRAESVA_Advertising_IP4:
@@ -128,20 +127,20 @@ prototypes:
             - ShareLevelYellow
         description: IPv4 classes delivering advertising email traffic only
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: IPv4
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.advertising_ip4
-		url: https://repo.libraesva.com/ioc/ip.black.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: IPv4
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.advertising_ip4
+        url: https://repo.libraesva.com/ioc/ip.black.txt
         class: minemeld.ft.http.HttpFT
 
 
@@ -156,20 +155,20 @@ prototypes:
             - ShareLevelYellow
         description: IPv4 classess delivering bulk email traffic
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: IPv4
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.bulk_ip4
-		url: https://repo.libraesva.com/ioc/ip.grey.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: IPv4
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.bulk_ip4
+        url: https://repo.libraesva.com/ioc/ip.grey.txt
         class: minemeld.ft.http.HttpFT
 
     LIBRAESVA_Bad_Email_IXHASH:
@@ -183,19 +182,19 @@ prototypes:
             - ShareLevelYellow
         description: Undesired email hashes, uses IX hash algoritm
         config:
-		age_out:
-		    default: null
-		    interval: 600
-		    sudden_death: true
-		attributes:
-		    confidence: 100
-		    direction: inbound
-		    share_level: yellow
-		    type: md5
-		ignore_regex: ^#.*
-		indicator:
-		    regex: ^.*
-		source_name: libraesva.bad_email_ixhash
-		url: https://repo.libraesva.com/ioc/ix.black.txt
+        age_out:
+            default: null
+            interval: 600
+            sudden_death: true
+        attributes:
+            confidence: 100
+            direction: inbound
+            share_level: yellow
+            type: md5
+        ignore_regex: ^#.*
+        indicator:
+            regex: ^.*
+        source_name: libraesva.bad_email_ixhash
+        url: https://repo.libraesva.com/ioc/ix.black.txt
         class: minemeld.ft.http.HttpFT
 


### PR DESCRIPTION
This prototype contains the following Libraesva IOC feeds:
- LIBRAESVA_Advertising_Domains: Domains delivering advertising only
- LIBRAESVA_Bulk_Email_Domains: Domains delivering bulk email traffic
- LIBRAESVA_White_Domains: Legit email and web domains
- LIBRAESVA_Malware_Domains: Malware,phishing,comprimised sites..
- LIBRAESVA_Advertising_IP4: IPv4 classes delivering advertising email traffic only
- LIBRAESVA_Bulk_IP4: IPv4 classess delivering bulk email traffic
- LIBRAESVA_Bad_Email_IXHASH: Undesired email hashes, uses IX hash algoritm