### PR TITLE
Create new prototypes and node for dagPusher enhancements which will

### DIFF
--- a/prototypes/stdlib.yml
+++ b/prototypes/stdlib.yml
@@ -872,6 +872,35 @@ prototypes:
         config:
           persistent_registered_ips: false
 
+    dagPusherNg:
+        author: MineMeld Core Team
+        development_status: EXPERIMENTAL
+        node_type: output
+        indicator_types:
+          - IPv4
+          - IPv6
+        tags: []
+        description: >
+            Push IP unicast indicators to PAN-OS 8.0 and greater devices
+            via DAG.
+        class: minemeld.ft.dag_ng.DagPusher
+        config: {}
+
+    nonpersistentDagPusherNg:
+        author: MineMeld Core Team
+        development_status: EXPERIMENTAL
+        node_type: output
+        indicator_types:
+          - IPv4
+          - IPv6
+        tags: []
+        description: >
+            Push IP unicast indicators to PAN-OS 8.0 and greater devices
+            via DAG. Generates non persistent registered IPs.
+        class: minemeld.ft.dag_ng.DagPusher
+        config:
+          persistent_registered_ips: false
+
     feedLCRedWithValue:
         author: MineMeld Core Team
         development_status: STABLE


### PR DESCRIPTION
require PAN-OS 8.0 and greater.  New node is based on dag.py.  This
first step validates each device is running PAN-OS 8.0 or greater; if
not an error is logged API requests to the device are not performed.